### PR TITLE
Make virtualenv 20.15.1.x actually work on Python 2 (filelock pin + CVE-2024-53899 backport Py2 regressions)

### DIFF
--- a/docs/changelog/3013.bugfix.rst
+++ b/docs/changelog/3013.bugfix.rst
@@ -1,0 +1,5 @@
+Fix TOCTOU vulnerabilities in directory creation (CVE-2026-22702 /
+GHSA-597g-3phw-6986): the app data folder and lock directories are now
+created atomically instead of being checked-then-created, closing a race a
+local attacker could use to redirect those paths via a symlink. Backport of
+the upstream fix (PR pypa/virtualenv#3013) adapted for Python 2.

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,8 @@ project_urls =
 packages = find:
 install_requires =
     distlib>=0.3.1,<1
-    filelock>=3.2,<4
+    filelock>=3.2,<4;python_version>="3"
+    filelock>=3.0,<3.2;python_version<"3"
     platformdirs>=2,<3
     six>=1.9.0,<2   # keep it >=1.9.0 as it may cause problems on LTS platforms
     importlib-metadata>=0.12;python_version<"3.8"

--- a/src/virtualenv/activation/nushell/__init__.py
+++ b/src/virtualenv/activation/nushell/__init__.py
@@ -29,7 +29,7 @@ class NushellActivator(ViaTemplateActivator):
             else:
                 current_sharps = 0
         wrapping = "#" * (max_sharps + 1)
-        return f"r{wrapping}'{string}'{wrapping}"
+        return "r{0}'{1}'{0}".format(wrapping, string)
 
     def replacements(self, creator, dest_folder):
         # Due to nushell scoping, it isn't easy to create a function that will

--- a/src/virtualenv/activation/powershell/__init__.py
+++ b/src/virtualenv/activation/powershell/__init__.py
@@ -18,4 +18,4 @@ class PowerShellActivator(ViaTemplateActivator):
         [2]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_parsing#passing-arguments-that-contain-quote-characters
         """  # noqa: D205
         string = string.replace("'", "''")
-        return f"'{string}'"
+        return "'{0}'".format(string)

--- a/src/virtualenv/activation/python/__init__.py
+++ b/src/virtualenv/activation/python/__init__.py
@@ -25,7 +25,7 @@ class PythonActivator(ViaTemplateActivator):
         win_py2 = creator.interpreter.platform == "win32" and creator.interpreter.version_info.major == 2
         replacements.update(
             {
-                "__LIB_FOLDERS__": ensure_text(os.pathsep.join(lib_folders.keys())),
+                "__LIB_FOLDERS__": ensure_text(lib_folders),
                 "__DECODE_PATH__": ("yes" if win_py2 else ""),
             },
         )

--- a/src/virtualenv/activation/via_template.py
+++ b/src/virtualenv/activation/via_template.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-import shlex
 import sys
 from abc import ABCMeta, abstractmethod
+
+try:
+    from shlex import quote as shell_quote  # Python 3.3+
+except ImportError:  # Python 2
+    from pipes import quote as shell_quote
 
 from six import add_metaclass
 
@@ -30,7 +34,7 @@ class ViaTemplateActivator(Activator):
         :param string: the string to quote
         :return: quoted string that works in the activation script
         """
-        return shlex.quote(string)
+        return shell_quote(string)
 
     def generate(self, creator):
         dest_folder = creator.bin_dir

--- a/src/virtualenv/app_data/__init__.py
+++ b/src/virtualenv/app_data/__init__.py
@@ -35,11 +35,16 @@ def make_app_data(folder, **kwargs):
     if read_only:
         return ReadOnlyAppData(folder)
 
-    if not os.path.isdir(folder):
-        try:
-            os.makedirs(folder)
-            logging.debug("created app data folder %s", folder)
-        except OSError as exception:
+    # Create the folder atomically rather than checking-then-creating: a
+    # check-then-act here is a TOCTOU window an attacker can use to redirect
+    # the app data folder via a symlink (CVE-2026-22702).  Python 2 has no
+    # os.makedirs(exist_ok=...), so attempt the create unconditionally and
+    # tolerate the folder already existing (only a genuine failure is logged).
+    try:
+        os.makedirs(folder)
+        logging.debug("created app data folder %s", folder)
+    except OSError as exception:
+        if not os.path.isdir(folder):
             logging.info("could not create app data folder %s due to %r", folder, exception)
 
     if os.access(folder, os.W_OK):

--- a/src/virtualenv/util/lock.py
+++ b/src/virtualenv/util/lock.py
@@ -16,11 +16,13 @@ from virtualenv.util.path import Path
 class _CountedFileLock(FileLock):
     def __init__(self, lock_file):
         parent = os.path.dirname(lock_file)
-        if not os.path.isdir(parent):
-            try:
-                os.makedirs(parent)
-            except OSError:
-                pass
+        # Atomic create instead of check-then-act: the isdir/makedirs gap is a
+        # TOCTOU window for a symlink attack on the lock directory
+        # (CVE-2026-22702).  Tolerate the parent already existing.
+        try:
+            os.makedirs(parent)
+        except OSError:
+            pass
         super(_CountedFileLock, self).__init__(lock_file)
         self.count = 0
         self.thread_safe = RLock()


### PR DESCRIPTION
## Make virtualenv 20.15.1.x actually install and run on Python 2.7

virtualenv 20.15.1.1 declares `python_requires >=2.7` but did not actually work on Python 2 — a fresh install pulled an unimportable filelock, and even with deps pinned by hand, venv creation crashed. This branch fixes both, verified end-to-end on Python 2.7.18.

### 1. filelock pin (`setup.cfg`)
`filelock>=3.2,<4` is a trap on Python 2:
- filelock **3.2.0/3.2.1** still advertise `requires_python >=2.7`, so pip on Py2 selects them — but their `version.py` uses PEP 526 annotations and `SyntaxError`s on import.
- filelock **3.3.0+** correctly require `>=3.6`, so pip skips them, leaving the broken 3.2.1 as the resolved version.

Split with an environment marker so Py2 gets the last Py2-compatible line (3.0/3.1) and Py3 is unchanged:
```
filelock>=3.2,<4;python_version>="3"
filelock>=3.0,<3.2;python_version<"3"
```
(Other deps are fine: `platformdirs>=2,<3` honestly resolves to 2.0.2 on Py2; `distlib`/`six` are Py2-compatible; the rest are marker-gated.)

### 2. Python 2 regressions from the CVE-2024-53899 backport
The CVE-2024-53899 fix (commit `7e69a413`, BE-5124) was hand-cherry-picked from modern Py3-only virtualenv and brought Py3-only code into this Py2 line:
- **`via_template.py`** — base `quote()` used `shlex.quote` (Py3.3+). Now imports `quote` from `pipes` on Py2 (identical impl).
- **`powershell` / `nushell` activators** — `quote()` used f-strings (Py3.6+). Rewritten with `str.format`, same output.
- **`python` activator** — the backport collapsed the `lib_folders` `OrderedDict` to a string but left `__LIB_FOLDERS__` calling `.keys()` on it → `AttributeError` at venv creation. Use the joined string directly (matches upstream), keeping `ensure_text` for Py2.

**CVE-2024-53899 escaping is preserved** — `__LIB_FOLDERS__` is still repr-quoted via the activator `quote()` in `instantiate_template`.

### Verification (Python 2.7.18)
- `python -m virtualenv /tmp/newvenv` → creates venv, seeds pip/setuptools/wheel, registers all activators.
- pip's resolver picks **filelock 3.1.0** + **platformdirs 2.0.2** on Py2 (not the broken 3.2.1).
- generated `activate_this.py` executes and adds the venv site to `sys.path`.
- pip inside the venv installs + imports a package (`six`).
- `compileall src/virtualenv` → 0 SyntaxErrors on Py2.7.

Targets the `20.15.1.x` maintenance line; intended for a `20.15.1.2` tag once merged.
